### PR TITLE
Add aria-label to carousel navigation buttons for accessibility

### DIFF
--- a/src/components/Dots.js
+++ b/src/components/Dots.js
@@ -9,6 +9,7 @@ const Dots = ({ imgIndex, setImgIndex, images }) => {
           key={idx}
           onClick={() => setImgIndex(idx)}
           className={`${styles.dot} ${imgIndex === idx ? styles.active : ''}`}
+          aria-label={`Slide ${idx + 1}`}
         />
       ))}
     </div>


### PR DESCRIPTION
### Overview
Added aria-label attributes to carousel navigation buttons to improve accessibility.

### Changes
Added aria-label to each carousel navigation button.

### Testing
Verified buttons now have aria-label attributes and are read correctly by screen readers.