### PR TITLE
Render different header nav logo for light and dark mode

### DIFF
--- a/src/components/common/Navigation.js
+++ b/src/components/common/Navigation.js
@@ -1,24 +1,61 @@
 'use client'
 
-import React, { useContext } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import Link from 'next/link'
 import { DataContext } from '../contexts/DataContext'
 import ThemeToggleButton from './ToggleThemeButton'
 
 const Navigation = () => {
   const { data } = useContext(DataContext)
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    // Update the theme based on body class
+    const updateTheme = () => {
+      if (document.body.classList.contains('dark')) {
+        setTheme('dark')
+      } else {
+        setTheme('light')
+      }
+    }
+
+    // Initial check
+    updateTheme()
+
+    // Listen for changes to the body's class list
+
+    //https://stackoverflow.com/questions/3219758/detect-changes-in-the-dom
+    //https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+    const observer = new MutationObserver(updateTheme)
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+
+    // Cleanup observer on unmount
+    return () => observer.disconnect()
+  }, [])
 
   // Check if data is available
   if (!data || !data.headerData) return <div>Loading...</div>
 
   const { headerData } = data
-  const { navigation_logo_svg, navigation_links } = headerData?.acf || {}
+  const {
+    light_mode_navigation_logo_svg,
+    dark_mode_navigation_logo_svg,
+    navigation_links,
+  } = headerData?.acf || {}
 
   return (
     <nav className='header-nav'>
       <div
         className='logo'
-        dangerouslySetInnerHTML={{ __html: navigation_logo_svg }}
+        dangerouslySetInnerHTML={{
+          __html:
+            theme === 'dark'
+              ? dark_mode_navigation_logo_svg
+              : light_mode_navigation_logo_svg,
+        }}
       ></div>
       <div>
         <ThemeToggleButton />


### PR DESCRIPTION
- Added a state variable to track the current theme.
- Used a _MutationObserver_ to watch for changes to the _class_ attribute on the _body_ element.
- Render the appropriate SVG logo based on the current theme.

Some refrences:
- [Detect changes in the DOM with MutationObserver](https://stackoverflow.com/questions/3219758/detect-changes-in-the-dom)
- [MDN Web Docs: MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)